### PR TITLE
Allow use from relative path

### DIFF
--- a/add.php
+++ b/add.php
@@ -8,10 +8,10 @@ if (isGET('draft') && isAdmin()) {
     $postEntry['content'] = cleanMagic($_POST['content']);
     $post = newEntry(cleanMagic($_POST['id']));
     saveEntry('drafts', $post, $postEntry);
-    redirect('view.php/draft/' . $post);
+    redirect('view.php?draft=' . $post);
   } else {
     $out['title'] = $lang['newPost'];
-    $out['content'] .= '<form action="/add.php/draft" method="post">
+    $out['content'] .= '<form action="./add.php?draft" method="post">
     <p>' . text('title') . '</p>
     <p>' . text('id') . '</p>
     <p>' . textarea('content') . '</p>
@@ -19,23 +19,23 @@ if (isGET('draft') && isAdmin()) {
     </form>';
     $out['content'] .= isPOST('content') ? box(cleanMagic($_POST['content'])) : '';
   }
-} else if (isGET('comment') && isValidEntry('posts', $_GET['comment'])) {
-  $postEntry = readEntry('posts', $_GET['comment']);
+} else if (isGET('comment') && isValidEntry('posts', GET('comment'))) {
+  $postEntry = readEntry('posts', GET('comment'));
   if ($postEntry['locked']) {
     home();
   } else if (checkBot() && check('name', $config['maxNameLength']) && check('content', $config['maxCommentLength'])) {
     $commentEntry['content'] = clean(cleanMagic($_POST['content']));
-    $commentEntry['post'] = $_GET['comment'];
+    $commentEntry['post'] = GET('comment');
     $comment = newEntry();
     $commentEntry['commenter'] = clean(cleanMagic($_POST['name']));
     saveEntry('comments', $comment, $commentEntry);
     $postEntry['comments'][$comment] = $comment;
-    saveEntry('posts', $_GET['comment'], $postEntry);
+    saveEntry('posts', GET('comment'), $postEntry);
     $_SESSION[$comment] = $comment;
-    redirect('view.php/post/' . $_GET['comment'] . '/pages/' . pageOf($comment, $postEntry['comment']) . '#' . $comment);
+    redirect('view.php?post=' . GET('comment') . '/pages/' . pageOf($comment, $postEntry['comment']) . '#' . $comment);
   } else {
     $out['title'] = $lang['addComment'] . ': ' . $postEntry['title'];
-    $out['content'] .= '<form action="/add.php/comment/' . $_GET['comment'] . '" method="post">
+    $out['content'] .= '<form action="./add.php?comment=' . GET('comment') . '" method="post">
     <p>' . text('name') . '</p>
     <p>' . textarea('content') . '</p>
     <p>' . submitSafe($lang['confirm']) . '</p>
@@ -50,7 +50,7 @@ if (isGET('draft') && isAdmin()) {
     home();
   } else {
     $out['title'] = $lang['addLink'];
-    $out['content'] .= '<form action="/add.php/link" method="post">
+    $out['content'] .= '<form action="./add.php?link" method="post">
     <p>' . text('name') . '</p>
     <p>' . text('url') . '</p>
     <p>' . submitAdmin($lang['confirm']) . '</p>
@@ -64,7 +64,7 @@ if (isGET('draft') && isAdmin()) {
     home();
   } else {
     $out['title'] = $lang['addTag'];
-    $out['content'] .= '<form action="/add.php/tag" method="post">
+    $out['content'] .= '<form action="./add.php?tag" method="post">
     <p>' . text('name') . '</p>
     <p>' . submitAdmin($lang['confirm']) . '</p>
     </form>';

--- a/auth.php
+++ b/auth.php
@@ -8,7 +8,7 @@ if (isGET('login')) {
     home();
   } else {
     $out['title'] = $lang['login'];
-    $out['content'] .= '<form action="/auth.php/login" method="post">
+    $out['content'] .= '<form action="./auth.php?login" method="post">
     <p>' . password('password') . '</p>
     <p>' . submitSafe($lang['confirm']) . '</p>
     </form>';
@@ -18,7 +18,7 @@ if (isGET('login')) {
   home();
 } else if (isGET('test') && isAdmin()) {
   $out['title'] = $lang['login'];
-  $out['content'] .= '<form action="/auth.php/test" method="post">
+  $out['content'] .= '<form action="./auth.php?test" method="post">
   <p>' . password('password') . '</p>
   <p>' . submitAdmin($lang['confirm']) . '</p>
   </form>';
@@ -28,5 +28,5 @@ if (isGET('login')) {
   home();
 }
 
-require 'templates/page.php';
+require './templates/page.php';
 ?>

--- a/css/main.css
+++ b/css/main.css
@@ -8,7 +8,7 @@ input, textarea, select {
   color: #000;
 }
 html {
-  background: #FFF url(/img/code-bg.png) 0 0 repeat-x;
+  background: #FFF url(../img/code-bg.png) 0 0 repeat-x;
 }
 body {
   max-width: 860px;
@@ -30,8 +30,9 @@ input[type="text"], input[type="password"], textarea {
 textarea { width: 98%; }
 input[type="text"] { width: 50%; }
 .block { font-size: 12px; }
-code, pre, .block { line-height: 100%; }
-code, pre, tt, .block { font-family: 'Anonymous Pro', monospace; }
+code, pre, .block { line-height: 120%; }
+code, pre, tt, .block { font-family: 'Courier, Anonymous Pro', monospace; }
+code, pre { padding-left: 30px; }
 .post .img { max-width: 100%; border: 0; display: block; margin: 10px auto; }
 .post iframe { border: 0; display: block; margin: 10px auto; }
 .block {
@@ -74,10 +75,10 @@ code, pre, tt, .block { font-family: 'Anonymous Pro', monospace; }
   font-size: 10px;
   vertical-align: top;
 }
-#menu .ctl .login { padding-left: 16px; width: 0; overflow: hidden; background: url(/img/lock16.png) 0 0 no-repeat; }
-#menu .ctl .logout { background: url(/img/unlock16.png) 0 0 no-repeat; }
-#menu .ctl .postfeed { background: url(/img/feed16.png) 0 0 no-repeat; }
-#menu .ctl .commentfeed { background: url(/img/feed16.png) 0 50% no-repeat; }
+#menu .ctl .login { padding-left: 16px; width: 0; overflow: hidden; background: url(../img/lock16.png) 0 0 no-repeat; }
+#menu .ctl .logout { background: url(../img/unlock16.png) 0 0 no-repeat; }
+#menu .ctl .postfeed { background: url(../img/feed16.png) 0 0 no-repeat; }
+#menu .ctl .commentfeed { background: url(../img/feed16.png) 0 50% no-repeat; }
 #menu .ctl .search { display: inline; } /* inline-block not working in IE7 for form */
 #menu .ctl .search input.text {
   width: 179px; height: 16px;
@@ -91,7 +92,7 @@ code, pre, tt, .block { font-family: 'Anonymous Pro', monospace; }
   width: 16px; height: 16px;
   border: 0; margin: 0 0 0 4px; padding: 0;
   vertical-align: top;
-  background: url(/img/search16.png) 50% 50% no-repeat;
+  background: url(../img/search16.png) 50% 50% no-repeat;
   cursor: pointer;
 }
 #footer { clear: both; font-size: 13px; padding: 10px 0; text-align: right; color: #333; }
@@ -119,14 +120,14 @@ code, pre, tt, .block { font-family: 'Anonymous Pro', monospace; }
   padding-left: 20px;
   line-height: 16px;
   font-size: 13px;
-  background: url(/img/comments16.png) 0 0 no-repeat;
+  background: url(../img/comments16.png) 0 0 no-repeat;
 }
 .info { padding-top: 5px; }
 .tags { margin: 5px 0 10px 8px; }
 .info a, .tags a {
   display: inline-block; min-height: 16px;
   margin: 5px 10px 0 0; padding-left: 20px;
-  background: url(/img/tag16.png) 0 50% no-repeat;
+  background: url(../img/tag16.png) 0 50% no-repeat;
   font-size: 12px;
 }
 .comment:target { background-color: #FFD; }
@@ -150,9 +151,9 @@ a.add, a.edit, a.delete, a.publish {
   width: 16px; height: 16px;
   margin-left: 4px;
   vertical-align: middle;
-  background: url(/img/new16.png) 50% 50% no-repeat;
+  background: url(../img/new16.png) 50% 50% no-repeat;
 }
-a.edit { background: url(/img/edit16.png) 50% 50% no-repeat; }
-a.delete { background: url(/img/delete16.png) 50% 50% no-repeat; }
-a.publish { background: url(/img/publish16.png) 50% 50% no-repeat; }
+a.edit { background: url(../img/edit16.png) 50% 50% no-repeat; }
+a.delete { background: url(../img/delete16.png) 50% 50% no-repeat; }
+a.publish { background: url(../img/publish16.png) 50% 50% no-repeat; }
 .div { text-align: center; color: #DDD; }

--- a/delete.php
+++ b/delete.php
@@ -3,7 +3,7 @@ $out = array();
 require 'header.php';
 
 if (isGET('post') && isAdmin()) {
-  $post = $_GET['post'];
+  $post = GET('post');
   $postEntry = readEntry('posts', $post);
   deleteEntry('posts', $post);
   foreach ($postEntry['tags'] as $tag) {
@@ -15,21 +15,21 @@ if (isGET('post') && isAdmin()) {
     deleteEntry('comments', $comment);
   home();
 } else if (isGET('draft') && isAdmin()) {
-  deleteEntry('drafts', $_GET['draft']);
+  deleteEntry('drafts', GET('draft'));
   home();
-} else if (isGET('comment') && (isAdmin() || isAuthor($_GET['comment']))) {
-  $comment = $_GET['comment'];
+} else if (isGET('comment') && (isAdmin() || isAuthor(GET('comment')))) {
+  $comment = GET('comment');
   $commentEntry = readEntry('comments', $comment);
   deleteEntry('comments', $comment);
   $postEntry = readEntry('posts', $commentEntry['post']);
   unset($postEntry['comments'][$comment]);
   saveEntry('posts', $commentEntry['post'], $postEntry);
-  redirect('view.php/post/' . $commentEntry['post'] . '#comments');
+  redirect('view.php?post=' . $commentEntry['post'] . '#comments');
 } else if (isGET('link') && isAdmin()) {
-  deleteEntry('links', $_GET['link']);
+  deleteEntry('links', GET('link'));
   home();
 } else if (isGET('tag') && isAdmin()) {
-  $tag = $_GET['tag'];
+  $tag = GET('tag');
   $tagEntry = readEntry('tags', $tag);
   deleteEntry('tags', $tag);
   foreach ($tagEntry['posts'] as $post) {

--- a/edit.php
+++ b/edit.php
@@ -2,8 +2,8 @@
 $out = array();
 require 'header.php';
 
-if (isGET('post') && isAdmin() && isValidEntry('posts', $_GET['post'])) {
-  $post = $_GET['post'];
+if (isGET('post') && isAdmin() && isValidEntry('posts', GET('post'))) {
+  $post = GET('post');
   $postEntry = readEntry('posts', $post);
   if (check('title') && check('content')) {
     $postEntry['title'] = clean(cleanMagic($_POST['title']));
@@ -24,7 +24,7 @@ if (isGET('post') && isAdmin() && isValidEntry('posts', $_GET['post'])) {
       $tagEntry['posts'][$post] = $post;
       saveEntry('tags', $tag, $tagEntry);
     }
-    redirect('view.php/post/' . $post);
+    redirect('view.php?post=' . $post);
   } else {
     $tagOptions = array();
     foreach (listEntry('tags') as $tag) {
@@ -32,7 +32,7 @@ if (isGET('post') && isAdmin() && isValidEntry('posts', $_GET['post'])) {
       $tagOptions[$tag] = $tagEntry['name'];
     }
     $out['title'] = $lang['editPost'] . ': ' . $postEntry['title'];
-    $out['content'] .= '<form action="/edit.php/post/' . $post . '" method="post">
+    $out['content'] .= '<form action="./edit.php?post=' . $post . '" method="post">
     <p>' . text('title', $postEntry['title']) . '</p>
     <p>' . textarea('content', clean($postEntry['content'])) . '</p>
     <p>' . select('locked', array('yes' => $lang['yes'], 'no' => $lang['no']), $postEntry['locked'] ? 'yes' : 'no') . '</p>
@@ -41,41 +41,41 @@ if (isGET('post') && isAdmin() && isValidEntry('posts', $_GET['post'])) {
     </form>';
     $out['content'] .= isPOST('content') ? box(cleanMagic($_POST['content'])) : '';
   }
-} else if (isGET('draft') && isAdmin() && isValidEntry('drafts', $_GET['draft'])) {
-  $draft = $_GET['draft'];
+} else if (isGET('draft') && isAdmin() && isValidEntry('drafts', GET('draft'))) {
+  $draft = GET('draft');
   $draftEntry = readEntry('drafts', $draft);
   if (check('title') && check('content')) {
     $draftEntry['title'] = clean(cleanMagic($_POST['title']));
     $draftEntry['content'] = cleanMagic($_POST['content']);
     saveEntry('drafts', $draft, $draftEntry);
-    redirect('view.php/draft/' . $draft);
+    redirect('view.php?draft=' . $draft);
   } else {
     $out['title'] = $lang['editDraft'] . ': ' . $draftEntry['title'];
-    $out['content'] .= '<form action="/edit.php/draft/' . $draft . '" method="post">
+    $out['content'] .= '<form action="./edit.php?draft=' . $draft . '" method="post">
     <p>' . text('title', $draftEntry['title']) . '</p>
     <p>' . textarea('content', clean($draftEntry['content'])) . '</p>
     <p>' . submitAdmin($lang['confirm']) . '</p>
     </form>';
     $out['content'] .= isPOST('content') ? box(cleanMagic($_POST['content'])) : '';
   }
-} else if (isGET('comment') && (isAdmin() || isAuthor($_GET['comment'])) && isValidEntry('comments', $_GET['comment'])) {
-  $comment = $_GET['comment'];
+} else if (isGET('comment') && (isAdmin() || isAuthor(GET('comment'))) && isValidEntry('comments', GET('comment'))) {
+  $comment = GET('comment');
   $commentEntry = readEntry('comments', $comment);
   if (checkBot() && check('content', $config['maxCommentLength'])) {
     $commentEntry['content'] = clean(cleanMagic($_POST['content']));
     saveEntry('comments', $comment, $commentEntry);
     $postEntry = readEntry('posts', $commentEntry['post']);
-    redirect('view.php/post/' . $commentEntry['post'] . '/pages/' . pageOf($comment, $postEntry['comment']) . '#' . $comment);
+    redirect('view.php?post=' . $commentEntry['post'] . '/pages/' . pageOf($comment, $postEntry['comment']) . '#' . $comment);
   } else {
     $out['title'] = $lang['editComment'];
-    $out['content'] .= '<form action="/edit.php/comment/' . $comment. '" method="post">
+    $out['content'] .= '<form action="./edit.php?comment=' . $comment. '" method="post">
     <p>' . textarea('content', $commentEntry['content']) . '</p>
     <p>' . submitSafe($lang['confirm']) . '</p>
     </form>';
     $out['content'] .= isPOST('content') ? box(cleanMagic($_POST['content'])) : '';
   }
-} else if (isGET('link') && isAdmin() && isValidEntry('links', $_GET['link'])) {
-  $link = $_GET['link'];
+} else if (isGET('link') && isAdmin() && isValidEntry('links', GET('link'))) {
+  $link = GET('link');
   $linkEntry = readEntry('links', $link);
   if (check('name') && check('url')) {
     $linkEntry['name'] = clean(cleanMagic($_POST['name']));
@@ -84,21 +84,21 @@ if (isGET('post') && isAdmin() && isValidEntry('posts', $_GET['post'])) {
     home();
   } else {
     $out['title'] = $lang['editLink'] . ': ' . $linkEntry['name'];
-    $out['content'] .= '<form action="/edit.php/link/' . $link . '" method="post">
+    $out['content'] .= '<form action="./edit.php?link=' . $link . '" method="post">
     <p>' . text('name', $linkEntry['name']) . '</p>
     <p>' . text('url', $linkEntry['url']) . '</p>
     <p>' . submitAdmin($lang['confirm']) . '</p>
     </form>';
   }
-} else if (isGET('tag') && isAdmin() && isValidEntry('tags', $_GET['tag'])) {
-  $tagEntry = readEntry('tags', $_GET['tag']);
+} else if (isGET('tag') && isAdmin() && isValidEntry('tags', GET('tag'))) {
+  $tagEntry = readEntry('tags', GET('tag'));
   if (check('name')) {
     $tagEntry['name'] = clean(cleanMagic($_POST['name']));
-    saveEntry('tags', $_GET['tag'], $tagEntry);
+    saveEntry('tags', GET('tag'), $tagEntry);
     home();
   } else {
     $out['title'] = $lang['editTag'] . ': ' .$tagEntry['name'];
-    $out['content'] .= '<form action="/edit.php/tag/' . $_GET['tag'] . '" method="post">
+    $out['content'] .= '<form action="./edit.php?tag=' . GET('tag') . '" method="post">
     <p>' . text('name', $tagEntry['name']) . '</p>
     <p>' . submitAdmin($lang['confirm']) . '</p>
     </form>';

--- a/feed.php
+++ b/feed.php
@@ -31,7 +31,7 @@ if (isGET('comments')) {
       $itemData = readEntry('comments', $item);
       $parentData = readEntry('posts', $itemData['post']);
       $title = clean($itemData['commenter'] . $lang['commented'] . $parentData['title']);
-      $url = $out['baseURL'] . 'view.php/post/' . $itemData['post'] . '/pages/' . pageOf($item, $parentData['comments']) . '#' . $item;
+      $url = $out['baseURL'] . 'view.php?post=' . $itemData['post'] . '/pages/' . pageOf($item, $parentData['comments']) . '#' . $item;
       $out['content'] .= getFeedEntry($title, $url, toDate($item, 'c'), content($itemData['content']));
     }
   }
@@ -45,7 +45,7 @@ if (isGET('comments')) {
     foreach ($items as $item) {
       $itemData = readEntry('posts', $item);
       $title = clean($itemData['title']);
-      $url = $out['baseURL'] . 'view.php/post/' . $item;
+      $url = $out['baseURL'] . 'view.php?post=' . $item;
       $out['content'] .= getFeedEntry($title, $url, toDate($item, 'c'), $itemData['content'], $itemData['tags']);
     }
   }

--- a/header.php
+++ b/header.php
@@ -13,17 +13,17 @@ if (!isset($_SESSION['role']))
   $_SESSION['role'] = '';
 
 function home() {
-  redirect('/');
+  redirect('.');
 }
 
-$_GET = urlPath();
+// $_GET = urlPath();
 
 $out['baseURL'] = baseURL();
 $out['content'] = '';
 $out['error'] = '';
 
 // Links
-$out['addLink'] .= isAdmin() ? '<a href="/add.php/link" class="add"></a>' : '';
+$out['addLink'] .= isAdmin() ? '<a href="./add.php?link" class="add"></a>' : '';
 $out['linkListItems'] .= '';
 $links = listEntry('links');
 if ($links) {
@@ -34,12 +34,12 @@ if ($links) {
 }
 
 // Tags
-$out['addTag'] .= isAdmin() ? '<a href="/add.php/tag" class="add"></a>' : '';
+$out['addTag'] .= isAdmin() ? '<a href="./add.php?tag" class="add"></a>' : '';
 $out['tagLinks'] .= '';
 $tags = listEntry('tags');
 foreach ($tags as $tag) {
   $tagEntry = readEntry('tags', $tag);
-  $out['tagLinks'] .= ' <a href="/view.php/tag/' . $tag . '">' . $tagEntry['name'] . ' (' . count($tagEntry['posts']) . ')</a>';
+  $out['tagLinks'] .= ' <a href="./view.php?tag=' . $tag . '">' . $tagEntry['name'] . ' (' . count($tagEntry['posts']) . ')</a>';
 }
 
 // Archive
@@ -59,7 +59,7 @@ if ($archives) {
     $out['archiveListItems'] .= '<li>' . $year . '&nbsp;';
     foreach ($months as $month => $count) {
       $yearMonth = $year . '-' . $month;
-      $out['archiveListItems'] .= ' &nbsp;<a href="/view.php/archive/' . $yearMonth . '">' . date('M', strtotime($yearMonth)) . '&nbsp;(' . $count . ')</a>';
+      $out['archiveListItems'] .= ' &nbsp;<a href="./view.php?archive=' . $yearMonth . '">' . date('M', strtotime($yearMonth)) . '&nbsp;(' . $count . ')</a>';
     }
     $out['archiveListItems'] .= '</li>';
   }

--- a/include/ui.php
+++ b/include/ui.php
@@ -12,7 +12,11 @@ function cleanMagic($text) {
 }
 
 function isGET($name) {
-  return isset($_GET[$name]) && is_string($_GET[$name]);
+  return isset($_REQUEST[$name]) && is_string($_REQUEST[$name]);
+}
+
+function GET($name) {
+	return filter_input(INPUT_GET, $name);
 }
 
 function isPOST($name) {
@@ -39,8 +43,11 @@ function textarea($name, $default = '') {
 }
 
 function submitSafe($label) {
-  global $lang;
-  return '<img src="/captcha.php" alt="captcha"><br>' . $lang['captchaDescription'] . '<input type="text" name="captcha" style="width:100px">&emsp;<input type="submit" value="' . $label . '">';
+	global $lang;
+	return '<img src="./captcha.php" alt="captcha"><br>' . 
+		$lang['captchaDescription'] . 
+		'<input type="text" name="captcha" style="width:100px">&emsp;' .
+		'<input type="submit" value="' . $label . '">';
 }
 
 function submitAdmin($label) {
@@ -83,30 +90,41 @@ function checkBot() {
   global $lang;
   if (!isPOST('captcha'))
     return false;
-  if (isset($_SESSION['captcha']) && strtolower(cleanMagic($_POST['captcha'])) === $_SESSION['captcha'])
+  if (isset($_SESSION['captcha']) && (cleanMagic($_POST['captcha']) === $_SESSION['captcha']))
     return true;
-  message($lang['errorBot'] . ' "' . cleanMagic($_POST['captcha']) . '"');
+  message($lang['errorBot'] . ' "' . cleanMagic($_POST['captcha']) . '" needed "' . $_SESSION['captcha'] . '"' );
   return false;
 }
 
 function manageDraft($draft) {
-  return isAdmin() ? '<a href="/edit.php/draft/' . $draft . '" class="edit"></a><a href="/publish.php/draft/' . $draft . '" class="publish"></a><a href="/delete.php/draft/' . $draft . '" class="delete"></a>' : '';
+	return isAdmin() ? '<a href="./edit.php?draft=' . $draft . 
+		'" class="edit"></a><a href="./publish.php?draft=' . $draft . 
+		'" class="publish"></a><a href="/delete.php?draft=' . $draft . 
+		'" class="delete"></a>' : '';
 }
 
 function managePost($post) {
-  return isAdmin() ? '<a href="/edit.php/post/' . $post . '" class="edit"></a><a href="/delete.php/post/' . $post . '" class="delete"></a>' : '';
+	return isAdmin() ? '<a href="./edit.php?post=' . $post . 
+		'" class="edit"></a><a href="./delete.php?post=' . $post . 
+		'" class="delete"></a>' : '';
 }
 
 function manageComment($comment) {
-  return isAdmin() || isAuthor($comment) ? '<a href="/edit.php/comment/' . $comment . '" class="edit"></a><a href="/delete.php/comment/' . $comment . '" class="delete"></a>' : '';
+	return isAdmin() || isAuthor($comment) ? '<a href="./edit.php?comment=' . $comment . 
+		'" class="edit"></a><a href="./delete.php?comment=' . $comment . 
+		'" class="delete"></a>' : '';
 }
 
 function manageTag($tag) {
-  return isAdmin() ? '<a href="/edit.php/tag/' . $tag . '" class="edit"></a><a href="/delete.php/tag/' . $tag . '" class="delete"></a>' : '';
+	return isAdmin() ? '<a href="./edit.php?tag=' . $tag . 
+		'" class="edit"></a><a href="./delete.php?tag=' . $tag . 
+		'" class="delete"></a>' : '';
 }
 
 function manageLink($link) {
-  return isAdmin() ? '<a href="/edit.php/link/' . $link . '" class="edit"></a><a href="/delete.php/link/' . $link . '" class="delete"></a>' : '';
+	return isAdmin() ? '<a href="./edit.php?link=' . $link . 
+		'" class="edit"></a><a href="./delete.php?link=' . $link . 
+		'" class="delete"></a>' : '';
 }
 
 function paging($page, $pages, $loc) {
@@ -123,7 +141,7 @@ function paging($page, $pages, $loc) {
 }
 
 function page($pages) {
-  return isGET('pages') && $_GET['pages'] >= 1 && $_GET['pages'] <= $pages ? (int)$_GET['pages'] : 1;
+  return isGET('pages') && GET('pages') >= 1 && GET('pages') <= $pages ? (int)GET('pages') : 1;
 }
 
 function pages($items) {

--- a/include/util.php
+++ b/include/util.php
@@ -2,7 +2,7 @@
 function urlPath() {
   $out = array();
   if (isset($_SERVER['PATH_INFO'])) {
-    $info = explode('/', $_SERVER['PATH_INFO']);
+    $info = explode('./', $_SERVER['PATH_INFO']);
     $infoNum = count($info);
     for ($i = 1; $i < $infoNum; $i += 2) {
       if ($info[$i] !== '')

--- a/index.php
+++ b/index.php
@@ -16,13 +16,13 @@ if (isGET('drafts') && isAdmin()) {
       $out['content'] .= $first ? '' : '<div class="div">&middot; &middot; &middot; &middot; &middot;</div>';
       $first = false;
       $out['content'] .= '<div class="post">
-      <h2><a href="/view.php/draft/' . $draft . '">' . $draftEntry['title'] . manageDraft($draft) . '</a></h2>
+      <h2><a href="./view.php?draft=' . $draft . '">' . $draftEntry['title'] . manageDraft($draft) . '</a></h2>
       <div class="date">' . toDate($draft) . '</div>';
       $out['content'] .= '<div class="content">' . $draftEntry['content'] . '</div>
       </div>';
     }
   }
-  $out['content'] .= paging($page, $pages, '/index.php/drafts/all');
+  $out['content'] .= paging($page, $pages, './index.php?drafts=all');
 } else if (isGET('comments')) {
   $out['title'] = $lang['comments'];
   $comments = listEntry('comments');
@@ -39,7 +39,7 @@ if (isGET('drafts') && isAdmin()) {
       $postEntry = readEntry('posts', $commentEntry['post']);
       $title = $commentEntry['commenter'] . $lang['commented'] . $postEntry['title'];
       $pageOf = pageOf($comment, $postEntry['comments']);
-      $link = '/view.php/post/' . $commentEntry['post'] . '/pages/' . $pageOf . '#' . $comment;
+      $link = './view.php?post=' . $commentEntry['post'] . '/pages/' . $pageOf . '#' . $comment;
       $out['content'] .= '<div class="comment">
       <div class="title"><a href="' . $link . '">' . $title . manageComment($comment) . '</a></div>
       <div class="date">' . toDate($comment) . '</div>
@@ -48,7 +48,7 @@ if (isGET('drafts') && isAdmin()) {
     }
     $out['content'] .= '</div>';
   }
-  $out['content'] .= paging($page, $pages, '/index.php/comments/all');
+  $out['content'] .= paging($page, $pages, './index.php?comments=all');
 } else if (isGET('404')) {
   $out['title'] = 'HTTP 404';
   $out['content'] .= '<p>' . $lang['notFound'] . '</p>';
@@ -73,24 +73,24 @@ if (isGET('drafts') && isAdmin()) {
       }
       $first = false;
       $out['content'] .= '<div class="post">
-      <h2><a href="/view.php/post/' . $post . '">' . $postEntry['title'] . managePost($post) . '</a></h2>
+      <h2><a href="./view.php?post=' . $post . '">' . $postEntry['title'] . managePost($post) . '</a></h2>
       <div class="date">' . toDate($post) . '</div>';
       $out['content'] .= '<div class="info">';
       foreach ($postEntry['tags'] as $tag) {
         $tagEntry = readEntry('tags', $tag);
         $tagName = $tagEntry['name'];
-        $out['content'] .= '<a href="/view.php/tag/' . $tag . '">' . $tagName . '</a>';
+        $out['content'] .= '<a href="./view.php?tag=' . $tag . '">' . $tagName . '</a>';
       }
       $out['content'] .= '</div>';
       if (!$is_posts) {
         $out['content'] .= '<div class="content">' . $postEntry['content'] . '</div>';
       }
       $commentCount = $postEntry['comments'] ? count($postEntry['comments']) : 0;
-      $out['content'] .= '<div class="ccount"><a href="/view.php/post/' . $post . '#comments">' . $commentCount . ($commentCount != 1 ? $lang['ncomments'] : $lang['ncomment']) . '</a></div>';
+      $out['content'] .= '<div class="ccount"><a href="./view.php?post=' . $post . '#comments">' . $commentCount . ($commentCount != 1 ? $lang['ncomments'] : $lang['ncomment']) . '</a></div>';
       $out['content'] .= '</div>';
     }
   }
-  $out['content'] .= paging($page, $pages, $is_posts ? '/index.php/posts/all' : '/index.php');
+  $out['content'] .= paging($page, $pages, $is_posts ? './index.php?posts=all' : './index.php');
 }
 
 require 'templates/page.php';

--- a/publish.php
+++ b/publish.php
@@ -2,8 +2,8 @@
 $out = array();
 require 'header.php';
 
-if (isGET('draft') && isAdmin() && isValidEntry('drafts', $_GET['draft'])) {
-  $draft = $_GET['draft'];
+if (isGET('draft') && isAdmin() && isValidEntry('drafts', GET('draft'))) {
+  $draft = GET('draft');
   if (check('title') && check('content') && check('id')) {
     $post = newEntry(cleanMagic($_POST['id']));
     $postEntry['title'] = clean(cleanMagic($_POST['title']));
@@ -18,7 +18,7 @@ if (isGET('draft') && isAdmin() && isValidEntry('drafts', $_GET['draft'])) {
       saveEntry('tags', $tag, $tagEntry);
     }
     deleteEntry('drafts', $draft);
-    redirect('view.php/post/' . $post);
+    redirect('view.php?post=' . $post);
   } else {
     $draftEntry = readEntry('drafts', $draft);
     $tagOptions = array();
@@ -27,7 +27,7 @@ if (isGET('draft') && isAdmin() && isValidEntry('drafts', $_GET['draft'])) {
       $tagOptions[$tag] = $tagEntry['name'];
     }
     $out['title'] = $lang['publishPost'] . ': ' . $draftEntry['title'];
-    $out['content'] .= '<form action="/publish.php/draft/' . $draft . '" method="post">
+    $out['content'] .= '<form action="./publish.php?draft=' . $draft . '" method="post">
     <p>' . text('title', $draftEntry['title']) . '</p>
     <p>' . text('id', substr($draft, 20)) . '</p>
     <p>' . textarea('content', clean($draftEntry['content'])) . '</p>

--- a/search.php
+++ b/search.php
@@ -14,7 +14,7 @@ if (check('text')) {
   $out['content'] .= '<ul>';
   if ($foundPosts) {
     foreach ($foundPosts as $post => $title)
-      $out['content'] .= '<li><a href="/view.php/post/' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</li>';
+      $out['content'] .= '<li><a href="./view.php?post=' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</li>';
   }
   $out['content'] .= '</ul>';
 } else {

--- a/templates/feed.php
+++ b/templates/feed.php
@@ -7,8 +7,8 @@ echo '<?xml version="1.0" encoding="UTF-8"?>'
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="<?php echo $out['baseURL'];?>">
   <title><?php echo $config['title'];?></title>
   <subtitle><?php echo $out['title'];?></subtitle>
-  <link href="feed.php/<?php echo $out['type'];?>" rel="self"/>
-  <id><?php echo $out['baseURL'] . 'feed.php/' . $out['type'];?></id>
+  <link href="feed.php?<?php echo $out['type'];?>" rel="self"/>
+  <id><?php echo $out['baseURL'] . 'feed.php?' . $out['type'];?></id>
   <updated><?php echo date('c');?></updated>
   <author><name>Josef Jelinek</name></author><?php echo $out['content'];?>
 

--- a/templates/page.php
+++ b/templates/page.php
@@ -10,29 +10,33 @@ header('Content-Type: text/html; charset=UTF-8');
   <meta itemprop="name" content="<?php echo $config['title'] . ' - ' . $out['title'];?>">
   <meta itemprop="description" content="<?php echo $config['description'];?>">
   <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400|Anonymous+Pro:400,400italic&amp;subset=latin-ext,latin" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" type="text/css" href="/css/main.css">
-  <link rel="alternate" type="application/atom+xml" href="/feed.php/posts" title="<?php echo $config['title'];?>">
+  <link rel="stylesheet" type="text/css" href="./css/main.css">
+  <link rel="alternate" type="application/atom+xml" href="./feed.php?posts" title="<?php echo $config['title'];?>">
   <script type="text/javascript">
     /* analytics etc. */
   </script> 
 </head>
 <body>
+	<?php $root = baseURL() ?>
   <div id="header"><?php echo $config['title'];?></div>
   <div id="menu">
     <div class="nav">
-      <a href="/"><?php echo $lang['home'];?></a>
-      <a href="/index.php/posts"><?php echo $lang['posts'];?></a>
-      <a href="/index.php/comments"><?php echo $lang['comments'];?></a>
-      <?php if (isAdmin()) echo '<a href="/index.php/drafts">' . $lang['drafts'] . '</a>';?>
-      <?php if (isAdmin()) echo '<a href="/add.php/draft">' . $lang['newDraft'] . '</a>';?>
+		<?php echo '<a href="' . $root . '">' . $lang['home'] . '</a>' .
+			'<a href="' . $root . 'index.php?posts">' . $lang['posts'] . '</a>' . 
+			'<a href="' . $root . 'index.php?comments">' . $lang['comments'] . '</a>';
+		if (isAdmin()) {
+			echo '<a href="' . $root . 'index.php?drafts">' . $lang['drafts'] . '</a>' .
+				 '<a href="' . $root . 'add.php?draft">' . $lang['newDraft'] . '</a>';
+		}
+		?>
     </div>
     <div class="ctl">
-      <a href="/feed.php/posts" class="postfeed"><?php echo $lang['posts'];?></a>
-      <a href="/feed.php/comments" class="commentfeed"><?php echo $lang['comments'];?></a>
+      <a href="feed.php?posts" class="postfeed"><?php echo $lang['posts'];?></a>
+      <a href="feed.php?comments" class="commentfeed"><?php echo $lang['comments'];?></a>
       <?php echo isAdmin()
-        ? '<a href="/auth.php/logout" class="logout">' . $lang['logout'] . '</a>'
-        : '<a href="/auth.php/login" class="login">' . $lang['login'] . '</a>';?>
-      <form action="/search.php" method="post" class="search">
+        ? '<a href="auth.php?logout" class="logout">' . $lang['logout'] . '</a>'
+        : '<a href="auth.php?login" class="login">' . $lang['login'] . '</a>';?>
+      <form action="search.php" method="post" class="search">
         <input type="text" name="text" value="" class="text"><input type="submit" value="" class="submit">
       </form>
     </div>

--- a/view.php
+++ b/view.php
@@ -2,18 +2,18 @@
 $out = array();
 require 'header.php';
 
-if (isGET('post') && isValidEntry('posts', $_GET['post'])) {
-  $postEntry = readEntry('posts', $_GET['post']);
+if (isGET('post') && isValidEntry('posts', GET('post'))) {
+  $postEntry = readEntry('posts', GET('post'));
   $out['title'] = $postEntry['title'];
   $out['titleHtml'] = '';
   $out['content'] .= '<div class="post">
-  <h1 class="title">' . $out['title'] . managePost($_GET['post']) . '</h1>
-  <div class="date">' . toDate($_GET['post']) . '</div>
+  <h1 class="title">' . $out['title'] . managePost(GET('post')) . '</h1>
+  <div class="date">' . toDate(GET('post')) . '</div>
   <div class="info">';
   foreach ($postEntry['tags'] as $tag) {
     $tagEntry = readEntry('tags', $tag);
     $tagName = $tagEntry['name'];
-    $out['content'] .= '<a href="/view.php/tag/' . $tag . '">' . $tagName . '</a>';
+    $out['content'] .= '<a href="./view.php?tag=' . $tag . '">' . $tagName . '</a>';
   }
   $out['content'] .= '</div>
   <div class="content">' . $postEntry['content'] . '</div>
@@ -39,53 +39,53 @@ if (isGET('post') && isValidEntry('posts', $_GET['post'])) {
   } else {
     $out['content'] .= '<div id="comments"></div>';
   }
-  $out['content'] .= paging($page, $pages, '/view.php/post/' . $_GET['post'] . '#comments');
+  $out['content'] .= paging($page, $pages, './view.php?post=' . GET('post') . '#comments');
   if (!$postEntry['locked']) {
-    $out['content'] .= '<form action="/add.php/comment/' . $_GET['post'] . '" method="post">
+    $out['content'] .= '<form action="./add.php?comment=' . GET('post') . '" method="post">
     <p>' . text('name') . '</p>
     <p>' . textarea('content') . '</p>
     <p>' . submitSafe('send') . '</p>
     </form>';
   }
-} else if (isGET('draft') && isValidEntry('drafts', $_GET['draft'])) {
-  $draftEntry = readEntry('drafts', $_GET['draft']);
+} else if (isGET('draft') && isValidEntry('drafts', GET('draft'))) {
+  $draftEntry = readEntry('drafts', GET('draft'));
   $out['title'] = $draftEntry['title'];
   $out['titleHtml'] = '';
   $out['content'] .= '<div class="post">
-  <h1 class="title">' . $out['title'] . manageDraft($_GET['draft']) . '</h1>
-  <div class="date">' . toDate($_GET['draft']) . '</div>';
+  <h1 class="title">' . $out['title'] . manageDraft(GET('draft')) . '</h1>
+  <div class="date">' . toDate(GET('draft')) . '</div>';
   $out['content'] .= '<div class="content">' . $draftEntry['content'] . '</div>
   </div>';
-} else if (isGET('tag') && isValidEntry('tags', $_GET['tag'])) {
-  $tagEntry = readEntry('tags', $_GET['tag']);
+} else if (isGET('tag') && isValidEntry('tags', GET('tag'))) {
+  $tagEntry = readEntry('tags', GET('tag'));
   $out['title'] = $tagEntry['name'];
-  $out['titleHtml'] .= '<h1>' . $out['title'] . manageTag($_GET['tag']) . '</h1>';
+  $out['titleHtml'] .= '<h1>' . $out['title'] . manageTag(GET('tag')) . '</h1>';
   $out['content'] .= '';
   if ($tagEntry['posts']) {
     foreach ($tagEntry['posts'] as $post) {
       $postEntry = readEntry('posts', $post);
       $title = $postEntry['title'];
-      $out['content'] .= '<p><a href="/view.php/post/' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</p>';
+      $out['content'] .= '<p><a href="./view.php?post=' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</p>';
     }
   }
-} else if (isGET('archive') && strlen($_GET['archive']) === 7) {
+} else if (isGET('archive') && strlen(GET('archive')) === 7) {
   $archivedPosts = array();
   foreach (listEntry('posts') as $post)
-    if ($_GET['archive'] === substr($post, 0, 7))
+    if (GET('archive') === substr($post, 0, 7))
       $archivedPosts[] = $post;
   if (!$archivedPosts) {
-    redirect('index.php/404');
+    redirect('index.php?404');
   } else {
-    $out['title'] = date('M Y', strtotime($_GET['archive']));
+    $out['title'] = date('M Y', strtotime(GET('archive')));
     $out['content'] .= '';
     foreach ($archivedPosts as $post) {
       $postEntry = readEntry('posts', $post);
       $title = $postEntry['title'];
-      $out['content'] .= '<p><a href="/view.php/post/' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</p>';
+      $out['content'] .= '<p><a href="./view.php?post=' . $post . '">' . $title . '</a>' . managePost($post) . ' &mdash; ' . toDate($post) . '</p>';
     }
   }
 } else {
-  redirect('index.php/404');
+  redirect('index.php?404');
 }
 
 require 'templates/page.php';


### PR DESCRIPTION
There are in fact two changes:
1. Allow the blog to be in a relative path - as opposed to the root directory.
2. The path referencing system didn't work on my server - not sure why. So changed all access references from:
index.php/edit/apost
to:
index.php?edit=apost

Extra Info: Whenever the first form is used, the generated html loads without any of the CSS rules being applied. I'm using Linux Mint with an Apache server. The second form works beautifully. I'm at a loss to explain as I really like the look of the first form. I'm not sure whether $_GET being a super-global has subtly changed since when the original version of this source was written.
